### PR TITLE
Add optional chaining to Instance_UUID and Schema_UUID

### DIFF
--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -107,8 +107,8 @@ export default class MQTTClient {
                 // Don't handle Node births
                 if (!topic.address.device) return;
 
-                let instance = payload.metrics.find((metric) => metric.name === "Instance_UUID").value;
-                let schema = payload.metrics.find((metric) => metric.name === "Schema_UUID").value;
+                let instance = payload.metrics.find((metric) => metric.name === "Instance_UUID")?.value;
+                let schema = payload.metrics.find((metric) => metric.name === "Schema_UUID")?.value;
 
                 // If we've already seen this birth, update it
                 if (this.aliasResolver?.[topic.address.group]?.[topic.address.node]?.[topic.address.device]) {


### PR DESCRIPTION
Ensured that a call to find on the metrics array in mqttclient.ts will not raise an error if there are no matching records. Previously, if no metric with name "Instance_UUID" or "Schema_UUID" was found, a TypeError would be thrown while attempting to access the 'value' property. The application to use optional chaining (?.) so it will return undefined rather than throwing an error.