### PR TITLE
Add data validation before writing to InfluxDB and minor updates

### DIFF
--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -241,7 +241,7 @@ export default class MQTTClient {
                 // Validate
                 numVal = Number(value);
                 if (!Number.isInteger(numVal)) {
-                    logger.warn(`${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
+                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
                 writeApi.writePoint(new Point(birth.name).intField('value', numVal));
@@ -253,7 +253,7 @@ export default class MQTTClient {
                 // Validate
                 numVal = Number(value);
                 if (!Number.isInteger(numVal)) {
-                    logger.warn(`${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
+                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
                 writeApi.writePoint(new Point(birth.name).uintField('value', numVal));
@@ -263,14 +263,14 @@ export default class MQTTClient {
                 // Validate
                 numVal = Number(value);
                 if (isNaN(parseFloat(numVal))) {
-                    logger.warn(`${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
+                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
                 writeApi.writePoint(new Point(birth.name).floatField('value', numVal));
                 break;
             case "Boolean":
                 if (typeof value != "boolean") {
-                    logger.warn(`${birth.name} should be a ${birth.type} but received ${value}. Not recording.`);
+                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${value}. Not recording.`);
                     return;
                 }
                 writeApi.writePoint(new Point(birth.name).booleanField('value', value));
@@ -282,7 +282,7 @@ export default class MQTTClient {
         }
 
         writeApi.close().then(() => {
-            logger.debug(`Written to InfluxDB: [${birth.type}] ${birth.name} = ${value}`);
+            logger.debug(`Written to InfluxDB: [${birth.type}] ${topic.address}/${birth.name} = ${value}`);
         })
     }
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "type": "module",
   "scripts": {
-    "start": "node dist/bin/ingester.js",
+    "start": "node --trace-warnings dist/bin/ingester.js",
     "start:shell": "k5start -Uf $CLIENT_KEYTAB npm run start",
     "dev": " npm run build && npm run start:dev",
     "build": "tsc && tsc-alias",

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -5,6 +5,6 @@
 
 # bin/bash
 tmpfile=$(mktemp)
-export CLIENT_KEYTAB="$(kubectl --kubeconfig ~/.kube/k3s.yaml get -n factory-plus secret krb5-keytabs -o jsonpath="{.data.sv1warehouse}" | base64 -d >"$tmpfile" && echo "$tmpfile")"
+export CLIENT_KEYTAB="$(kubectl --kubeconfig ~/.kube/fplus get -n factory-plus secret krb5-keytabs -o jsonpath="{.data.sv1warehouse}" | base64 -d >"$tmpfile" && echo "$tmpfile")"
 echo $CLIENT_KEYTAB
 npm run start:shell


### PR DESCRIPTION
Additional value checks have been implemented before writing to InfluxDB in order to ensure that only correct and valid data are written. Validation is done according to the data type. Besides, `--trace-warnings` option is added to the `start` script in `package.json` to get more descriptive error messages during runtime. Changes in `run-dev.sh` reflect updated kube config and namespace paths for retrieving secrets.