### PR TITLE
Refactor flushing strategy in MQTT client

### DIFF
--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -354,7 +354,7 @@ export default class MQTTClient {
         logger.debug(`Added to write buffer (${i}/${batchSize}): [${birth.type}] ${topic.address}/${birth.name} = ${value}`);
 
         if (i >= batchSize) {
-            this.flushBuffer('BATCH');
+            this.flushBuffer(`${batchSize} point BATCH`);
         }
     }
 


### PR DESCRIPTION
The new flushing strategy allows us to intercept the periodic flushes and reset the metric counter so that batch flushing stays in sync since the last flush.