### PR TITLE
Fix metric names

### DIFF
--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -290,12 +290,19 @@ export default class MQTTClient {
 
         if (value === null) return;
 
+        // Get the value after the last /
+        let metricName = birth.name.split('/').pop();
+
+        // Get the path as everything behind the last /
+        let path = birth.name.substring(0, birth.name.lastIndexOf("/"));
+
         writeApi.useDefaultTags({
             instance: birth.instance,
             schema: birth.schema,
             group: topic.address.group,
             node: topic.address.node,
-            device: topic.address.device
+            device: topic.address.device,
+            path: path,
         });
 
 
@@ -309,10 +316,10 @@ export default class MQTTClient {
                 // Validate
                 numVal = Number(value);
                 if (!Number.isInteger(numVal)) {
-                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
+                    logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(birth.name).intField('value', numVal));
+                writeApi.writePoint(new Point(`${metricName}_i`).intField('value', numVal));
                 break;
             case "UInt8":
             case "UInt16":
@@ -321,37 +328,37 @@ export default class MQTTClient {
                 // Validate
                 numVal = Number(value);
                 if (!Number.isInteger(numVal)) {
-                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
+                    logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(birth.name).uintField('value', numVal));
+                writeApi.writePoint(new Point(`${metricName}_u`).uintField('value', numVal));
                 break;
             case "Float":
             case "Double":
                 // Validate
                 numVal = Number(value);
                 if (isNaN(parseFloat(numVal))) {
-                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${numVal}. Not recording.`);
+                    logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(birth.name).floatField('value', numVal));
+                writeApi.writePoint(new Point(`${metricName}_d`).floatField('value', numVal));
                 break;
             case "Boolean":
                 if (typeof value != "boolean") {
-                    logger.warn(`${topic.address}/${birth.name} should be a ${birth.type} but received ${value}. Not recording.`);
+                    logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${value}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(birth.name).booleanField('value', value));
+                writeApi.writePoint(new Point(`${metricName}_b`).booleanField('value', value));
                 break;
             default:
-                writeApi.writePoint(new Point(birth.name).stringField('value', value));
+                writeApi.writePoint(new Point(`${metricName}_s`).stringField('value', value));
                 break;
 
         }
 
         i++;
 
-        logger.debug(`Added to write buffer (${i}/${batchSize}): [${birth.type}] ${topic.address}/${birth.name} = ${value}`);
+        logger.debug(`Added to write buffer (${i}/${batchSize}): [${birth.type}] ${topic.address}/${path}/${metricName} = ${value}`);
 
         if (i >= batchSize) {
             this.flushBuffer(`${batchSize} point BATCH`);

--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -296,6 +296,11 @@ export default class MQTTClient {
         // Get the path as everything behind the last /
         let path = birth.name.substring(0, birth.name.lastIndexOf("/"));
 
+        // Here we only currently store the InstanceUUID and SchemaUUID
+        // of the top-level birth certificate. It would be nice if we could
+        // also store the InstanceUUID and SchemaUUID of all nested schemas
+        // but unsure how to handle this in InfluxDB.
+
         writeApi.useDefaultTags({
             instance: birth.instance,
             schema: birth.schema,
@@ -319,7 +324,7 @@ export default class MQTTClient {
                     logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(`${metricName}_i`).intField('value', numVal));
+                writeApi.writePoint(new Point(`${metricName}:i`).intField('value', numVal));
                 break;
             case "UInt8":
             case "UInt16":
@@ -331,7 +336,7 @@ export default class MQTTClient {
                     logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(`${metricName}_u`).uintField('value', numVal));
+                writeApi.writePoint(new Point(`${metricName}:u`).uintField('value', numVal));
                 break;
             case "Float":
             case "Double":
@@ -341,17 +346,17 @@ export default class MQTTClient {
                     logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${numVal}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(`${metricName}_d`).floatField('value', numVal));
+                writeApi.writePoint(new Point(`${metricName}:d`).floatField('value', numVal));
                 break;
             case "Boolean":
                 if (typeof value != "boolean") {
                     logger.warn(`${topic.address}/${path}/${metricName} should be a ${birth.type} but received ${value}. Not recording.`);
                     return;
                 }
-                writeApi.writePoint(new Point(`${metricName}_b`).booleanField('value', value));
+                writeApi.writePoint(new Point(`${metricName}:b`).booleanField('value', value));
                 break;
             default:
-                writeApi.writePoint(new Point(`${metricName}_s`).stringField('value', value));
+                writeApi.writePoint(new Point(`${metricName}:s`).stringField('value', value));
                 break;
 
         }


### PR DESCRIPTION
Metrics are now stored in the InfluxDB database as the metric name, not the fully qualified path. Before, `Phases/1/Voltage` and `Phases/2/Voltage` would be two measurements. Now, they're both `Voltage` and have a `Path` tag of `Phases/1` and `Phases/2` respectively.

The datatype has also been added on to the name of the metric. Not best practice (probably), but prevents errors from arising when a metric has the same name and a different type.