### PR TITLE
Add handling for transient MQTT metrics

### DIFF
--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -315,7 +315,8 @@ export default class MQTTClient {
                         },
                         name: obj.name,
                         type: obj.type,
-                        alias: alias
+                        alias: alias,
+                        transient: !(obj.properties?.recordToDB?.value)
                     };
                     return acc;
                 }, {}));
@@ -399,6 +400,10 @@ export default class MQTTClient {
     writeToInfluxDB(birth, topic: Topic, value) {
 
         if (value === null) return;
+        if (birth.transient) {
+            logger.debug(`Metric ${birth.name} is transient, not writing to InfluxDB`);
+            return;
+        }
 
         // Get the value after the last /
         let metricName = birth.name.split('/').pop();


### PR DESCRIPTION
The modification ensures that transient MQTT metrics, which shouldn't be recorded to the database, are rightfully skipped. A new `transient` field is added to the object property, which is determined based on the `recordToDB` setting. Also, an additional check is included in `writeToInfluxDB` to avoid writing transient metrics.