### PR TITLE
Fix DDEATH handling

### DIFF
--- a/lib/mqttclient.ts
+++ b/lib/mqttclient.ts
@@ -1,6 +1,6 @@
 /*
  * AMRC InfluxDB Sparkplug Ingester
- * Copyright "2023" AMRC
+ * Copyright "2024" AMRC
  */
 
 import {ServiceClient, SpB, Topic, UUIDs} from "@amrc-factoryplus/utilities";
@@ -53,9 +53,7 @@ const keepAliveAgent = new Agent({
 })
 
 const influxDB = new InfluxDB({
-    url: influxURL,
-    token: influxToken,
-    transportOptions: {
+    url: influxURL, token: influxToken, transportOptions: {
         agent: keepAliveAgent,
     }
 })
@@ -70,8 +68,7 @@ const writeApi = influxDB.getWriteApi(influxOrganisation, process.env.INFLUX_BUC
     /* maximum time in millis to keep points in an unflushed batch, 0 means don't periodically flush */
     flushInterval: 0, // Never allow the package to flush: we'll flush manually
     /* maximum size of the retry buffer - it contains items that could not be sent for the first time */
-    maxBufferLines: 30_000,
-    /* the count of internally-scheduled retries upon write failure, the delays between write attempts follow an exponential backoff strategy if there is no Retry-After HTTP header */
+    maxBufferLines: 30_000, /* the count of internally-scheduled retries upon write failure, the delays between write attempts follow an exponential backoff strategy if there is no Retry-After HTTP header */
     maxRetries: 0, // do not retry writes
     // ... there are more write options that can be customized, see
     // https://influxdata.github.io/influxdb-client-js/influxdb-client.writeoptions.html and
@@ -333,15 +330,15 @@ export default class MQTTClient {
 
                 // If the death certificate is for a device then remove it from the known devices, otherwise remove the entire node
                 if (topic.address.isDevice()) {
-                logger.info(`💀 Received death certificate for ${topic.address.group}/${topic.address.node}/${topic.address.device}. Removing from known devices.`);
+                    logger.info(`💀 Received death certificate for ${topic.address.group}/${topic.address.node}/${topic.address.device}. Removing from known devices.`);
                     delete this.birthDebounce?.[topic.address.group]?.[topic.address.node]?.[topic.address.device]
                     delete this.aliasResolver?.[topic.address.group]?.[topic.address.node]?.[topic.address.device]
                     break;
                 } else {
                     logger.info(`💀💀💀 Received death certificate for entire node ${topic.address.group}/${topic.address.node}. Removing from known nodes.`);
-                delete this.birthDebounce?.[topic.address.group]?.[topic.address.node]
-                delete this.aliasResolver?.[topic.address.group]?.[topic.address.node]
-                break;
+                    delete this.birthDebounce?.[topic.address.group]?.[topic.address.node]
+                    delete this.aliasResolver?.[topic.address.group]?.[topic.address.node]
+                    break;
                 }
             case "DATA":
 
@@ -364,6 +361,12 @@ export default class MQTTClient {
 
                     logger.info(`✨ Device ${topic.address.group}/${topic.address.node}/${topic.address.device} is unknown, requesting birth certificate`);
 
+                    // Create debounce timout for this device
+                    this.setNestedValue(this.birthDebounce, [topic.address.group, topic.address.node, topic.address.device], true);
+                    setTimeout(() => {
+                        delete this.birthDebounce?.[topic.address.group]?.[topic.address.node]?.[topic.address.device];
+                    }, Math.floor(Math.random() * (10000 - 5000 + 1) + 5000));
+
                     // Request birth certificate
                     let response = await this.serviceClient.fetch({
                         service: UUIDs.Service.Command_Escalation,
@@ -378,12 +381,6 @@ export default class MQTTClient {
                     })
 
                     logger.info('📣 Birth certificate request sent for %s. Status: %s', topic.address, response.status);
-
-                    // Create debounce timout for this device
-                    this.setNestedValue(this.birthDebounce, [topic.address.group, topic.address.node, topic.address.device], true);
-                    setTimeout(() => {
-                        delete this.birthDebounce?.[topic.address.group]?.[topic.address.node]?.[topic.address.device];
-                    }, Math.floor(Math.random() * (10000 - 5000 + 1) + 5000));
 
                 }
                 break;


### PR DESCRIPTION
This fixes an issue whereby any device that publishes a DDEATH caused the ingester to completely forget all devices in that node.

It also moves the debounce initialisation to before the await call ensures that the debounce works correctly in high-traffic situations. Before, multiple data messages could trigger a rebirth before the debounce flag was set.
